### PR TITLE
return unchanged incoming opts, instead of undefined

### DIFF
--- a/src/javascripts/components/command-tool.es
+++ b/src/javascripts/components/command-tool.es
@@ -4,7 +4,7 @@ import {post} from "superagent";
 function coerceParams(params) {
   function coerce(opts, param) {
     if (param.key === "") {
-      return;
+      return opts;
     }
 
     if (param.type === "boolean") {


### PR DESCRIPTION
http posts to command api were not sent params.
the dynamic form containing the command options always end up with an empty option.
This way the coerceParams function's reducers always returned with "undefined",
causing the http post not sending anything.